### PR TITLE
feat: update babel and terser dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,18 @@
 			"name": "my-portfolio",
 			"version": "0.1.0",
 			"dependencies": {
-				"async": "^3.2.5",
+				"async": "^3.2.6",
 				"nth-check": "^2.1.1",
-				"react": "^18.2.0",
+				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
-				"react-helmet-async": "^2.0.4",
+				"react-helmet-async": "^2.0.5",
 				"react-icons": "^5.3.0",
 				"react-router-dom": "^6.26.2",
 				"react-scripts": "^5.0.1",
 				"web-vitals": "^4.2.3"
 			},
 			"devDependencies": {
-				"sass": "^1.79.3"
+				"sass": "^1.79.4"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -58,28 +58,28 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
-			"integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+			"integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
-			"integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+			"integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.24.7",
-				"@babel/helper-compilation-targets": "^7.24.7",
-				"@babel/helper-module-transforms": "^7.24.7",
-				"@babel/helpers": "^7.24.7",
-				"@babel/parser": "^7.24.7",
-				"@babel/template": "^7.24.7",
-				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7",
+				"@babel/generator": "^7.25.0",
+				"@babel/helper-compilation-targets": "^7.25.2",
+				"@babel/helper-module-transforms": "^7.25.2",
+				"@babel/helpers": "^7.25.0",
+				"@babel/parser": "^7.25.0",
+				"@babel/template": "^7.25.0",
+				"@babel/traverse": "^7.25.2",
+				"@babel/types": "^7.25.2",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -103,9 +103,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.7.tgz",
-			"integrity": "sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==",
+			"version": "7.25.1",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.1.tgz",
+			"integrity": "sha512-Y956ghgTT4j7rKesabkh5WeqgSFZVFwaPR0IWFm7KFHFmmJ4afbG49SmfW4S+GyRPx0Dy5jxEWA5t0rpxfElWg==",
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
 				"eslint-visitor-keys": "^2.1.0",
@@ -136,11 +136,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-			"integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+			"integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
 			"dependencies": {
-				"@babel/types": "^7.24.7",
+				"@babel/types": "^7.25.6",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
@@ -173,13 +173,13 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-			"integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+			"integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
 			"dependencies": {
-				"@babel/compat-data": "^7.24.7",
-				"@babel/helper-validator-option": "^7.24.7",
-				"browserslist": "^4.22.2",
+				"@babel/compat-data": "^7.25.2",
+				"@babel/helper-validator-option": "^7.24.8",
+				"browserslist": "^4.23.1",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -196,18 +196,16 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.7.tgz",
-			"integrity": "sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+			"integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-function-name": "^7.24.7",
-				"@babel/helper-member-expression-to-functions": "^7.24.7",
+				"@babel/helper-member-expression-to-functions": "^7.24.8",
 				"@babel/helper-optimise-call-expression": "^7.24.7",
-				"@babel/helper-replace-supers": "^7.24.7",
+				"@babel/helper-replace-supers": "^7.25.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/traverse": "^7.25.4",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -226,9 +224,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-regexp-features-plugin": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.24.7.tgz",
-			"integrity": "sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.2.tgz",
+			"integrity": "sha512-+wqVGP+DFmqwFD3EH6TMTfUNeqDehV3E/dl+Sd54eaXqm17tEUNbEIn4sVivVowbvUpOtIGxdo3GoXyDH9N/9g==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
 				"regexpu-core": "^5.3.1",
@@ -264,47 +262,13 @@
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
-		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-			"integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-			"dependencies": {
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-function-name": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-			"integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-			"dependencies": {
-				"@babel/template": "^7.24.7",
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-			"integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-			"dependencies": {
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.7.tgz",
-			"integrity": "sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
+			"integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
 			"dependencies": {
-				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/traverse": "^7.24.8",
+				"@babel/types": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -323,15 +287,14 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-			"integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+			"integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
 				"@babel/helper-module-imports": "^7.24.7",
 				"@babel/helper-simple-access": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
-				"@babel/helper-validator-identifier": "^7.24.7"
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"@babel/traverse": "^7.25.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -352,21 +315,21 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
-			"integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+			"integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-remap-async-to-generator": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.24.7.tgz",
-			"integrity": "sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.0.tgz",
+			"integrity": "sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-wrap-function": "^7.24.7"
+				"@babel/helper-wrap-function": "^7.25.0",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -376,13 +339,13 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.7.tgz",
-			"integrity": "sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
+			"integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-member-expression-to-functions": "^7.24.7",
-				"@babel/helper-optimise-call-expression": "^7.24.7"
+				"@babel/helper-member-expression-to-functions": "^7.24.8",
+				"@babel/helper-optimise-call-expression": "^7.24.7",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -415,21 +378,10 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-			"integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-			"dependencies": {
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-			"integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -443,34 +395,33 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-			"integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+			"integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.7.tgz",
-			"integrity": "sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.0.tgz",
+			"integrity": "sha512-s6Q1ebqutSiZnEjaofc/UKDyC4SbzV5n5SrA2Gq8UawLycr3i04f1dX4OzoQVnexm6aOCh37SQNYlJ/8Ku+PMQ==",
 			"dependencies": {
-				"@babel/helper-function-name": "^7.24.7",
-				"@babel/template": "^7.24.7",
-				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/template": "^7.25.0",
+				"@babel/traverse": "^7.25.0",
+				"@babel/types": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
-			"integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+			"integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
 			"dependencies": {
-				"@babel/template": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/template": "^7.25.0",
+				"@babel/types": "^7.25.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -491,9 +442,12 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-			"integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+			"integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+			"dependencies": {
+				"@babel/types": "^7.25.6"
+			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -502,12 +456,26 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.7.tgz",
-			"integrity": "sha512-TiT1ss81W80eQsN+722OaeQMY/G4yTb4G9JrqeiDADs3N8lbPMGldWi9x8tyqCW5NLx1Jh2AvkE6r6QvEltMMQ==",
+			"version": "7.25.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.3.tgz",
+			"integrity": "sha512-wUrcsxZg6rqBXG05HG1FPYgsP6EvwF4WpBbxIpWIIYnH8wG0gzx3yZY3dtEHas4sTAOGkbTsc9EGPxwff8lRoA==",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/traverse": "^7.25.3"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.0.tgz",
+			"integrity": "sha512-Bm4bH2qsX880b/3ziJ8KD711LT7z4u8CFudmjqle65AZj/HNUFhEf90dqYv6O86buWvSBmeQDjv0Tn2aF/bIBA==",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -517,11 +485,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.7.tgz",
-			"integrity": "sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.0.tgz",
+			"integrity": "sha512-lXwdNZtTmeVOOFtwM/WDe7yg1PL8sYhRk/XH0FzbR2HDQ0xC+EnQ/JHeoMYSavtU115tnUk0q9CDyq8si+LMAA==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -547,12 +515,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.7.tgz",
-			"integrity": "sha512-utA4HuR6F4Vvcr+o4DnjL8fCOlgRFGbeeBEGNg3ZTrLFw6VWG5XmUrvcQ0FjIYMU2ST4XcR2Wsp7t9qOAPnxMg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.0.tgz",
+			"integrity": "sha512-tggFrk1AIShG/RUQbEwt2Tr/E+ObkfwrPjR6BjbRvsx24+PSjK8zrq0GWPNCjo8qpRx4DuJzlcvWJqlm+0h3kw==",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -767,11 +735,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.7.tgz",
-			"integrity": "sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.25.6.tgz",
+			"integrity": "sha512-aABl0jHw9bZ2karQ/uUD6XP4u0SG22SJrOHFoL6XB1R7dTovOP4TzTlsxOYC5yQ1pdscVK2JTUnF6QL3ARoAiQ==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -781,11 +749,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.7.tgz",
-			"integrity": "sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
+			"integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -925,11 +893,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
-			"integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+			"integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -968,14 +936,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.7.tgz",
-			"integrity": "sha512-o+iF77e3u7ZS4AoAuJvapz9Fm001PuD2V3Lp6OSE4FYQke+cSewYtnek+THqGRWyQloRCyvWL1OkyfNEl9vr/g==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.4.tgz",
+			"integrity": "sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
-				"@babel/helper-remap-async-to-generator": "^7.24.7",
-				"@babel/plugin-syntax-async-generators": "^7.8.4"
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-remap-async-to-generator": "^7.25.0",
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/traverse": "^7.25.4"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1015,11 +983,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.7.tgz",
-			"integrity": "sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.0.tgz",
+			"integrity": "sha512-yBQjYoOjXlFv9nlXb3f1casSHOZkWr29NX+zChVanLg5Nc157CrbEX9D7hxxtTpuFy7Q0YzmmWfJxzvps4kXrQ==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1029,12 +997,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
-			"integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.4.tgz",
+			"integrity": "sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-create-class-features-plugin": "^7.25.4",
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1060,17 +1028,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.7.tgz",
-			"integrity": "sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz",
+			"integrity": "sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-compilation-targets": "^7.24.7",
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-function-name": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
-				"@babel/helper-replace-supers": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
+				"@babel/helper-compilation-targets": "^7.25.2",
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-replace-supers": "^7.25.0",
+				"@babel/traverse": "^7.25.4",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -1096,11 +1062,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.7.tgz",
-			"integrity": "sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.8.tgz",
+			"integrity": "sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1136,6 +1102,21 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.0.tgz",
+			"integrity": "sha512-YLpb4LlYSc3sCUa35un84poXoraOiQucUTTu8X1j18JV+gNa8E0nyUf/CjZ171IRGr4jEguF+vzJU66QZhn29g==",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^7.25.0",
+				"@babel/helper-plugin-utils": "^7.24.8"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/plugin-transform-dynamic-import": {
@@ -1184,11 +1165,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-flow-strip-types": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.7.tgz",
-			"integrity": "sha512-cjRKJ7FobOH2eakx7Ja+KpJRj8+y+/SiB3ooYm/n2UJfxu0oEaOoxOinitkJcPqv9KxS0kxTGPUaR7L2XcXDXA==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.2.tgz",
+			"integrity": "sha512-InBZ0O8tew5V0K6cHcQ+wgxlrjOw1W4wDXLkOTjLRD8GYhTSkxTVBtdy3MMtvYBrbAWa1Qm3hNoTc1620Yj+Mg==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/plugin-syntax-flow": "^7.24.7"
 			},
 			"engines": {
@@ -1214,13 +1195,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.7.tgz",
-			"integrity": "sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==",
+			"version": "7.25.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.1.tgz",
+			"integrity": "sha512-TVVJVdW9RKMNgJJlLtHsKDTydjZAbwIsn6ySBPQaEAUU5+gVvlJt/9nRmqVbsV/IBanRjzWoaAQKLoamWVOUuA==",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.24.7",
-				"@babel/helper-function-name": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-compilation-targets": "^7.24.8",
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/traverse": "^7.25.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1245,11 +1226,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-literals": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.7.tgz",
-			"integrity": "sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.2.tgz",
+			"integrity": "sha512-HQI+HcTbm9ur3Z2DkO+jgESMAMcYLuN/A7NRw9juzxAezN9AvqvUTnpKP/9kkYANz6u7dFlAyOu44ejuGySlfw==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1303,12 +1284,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.7.tgz",
-			"integrity": "sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
+			"integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-module-transforms": "^7.24.8",
+				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/helper-simple-access": "^7.24.7"
 			},
 			"engines": {
@@ -1319,14 +1300,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.7.tgz",
-			"integrity": "sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.0.tgz",
+			"integrity": "sha512-YPJfjQPDXxyQWg/0+jHKj1llnY5f/R6a0p/vP4lPymxLu7Lvl4k2WMitqi08yxwQcCVUUdG9LCUj4TNEgAp3Jw==",
 			"dependencies": {
-				"@babel/helper-hoist-variables": "^7.24.7",
-				"@babel/helper-module-transforms": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
-				"@babel/helper-validator-identifier": "^7.24.7"
+				"@babel/helper-module-transforms": "^7.25.0",
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1457,11 +1438,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.7.tgz",
-			"integrity": "sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.8.tgz",
+			"integrity": "sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
 			},
@@ -1487,12 +1468,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz",
-			"integrity": "sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.4.tgz",
+			"integrity": "sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-create-class-features-plugin": "^7.25.4",
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1533,11 +1514,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-constant-elements": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.7.tgz",
-			"integrity": "sha512-7LidzZfUXyfZ8/buRW6qIIHBY8wAZ1OrY9c/wTr8YhZ6vMPo+Uc/CVFLYY1spZrEQlD4w5u8wjqk5NQ3OVqQKA==",
+			"version": "7.25.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.25.1.tgz",
+			"integrity": "sha512-SLV/giH/V4SmloZ6Dt40HjTGTAIkxn33TVIHxNGNvo8ezMhrxBkzisj4op1KZYPIOHFLqhv60OHvX+YRu4xbmQ==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1561,15 +1542,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
-			"integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.2.tgz",
+			"integrity": "sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
 				"@babel/helper-module-imports": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/plugin-syntax-jsx": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/types": "^7.25.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1637,14 +1618,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.7.tgz",
-			"integrity": "sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.4.tgz",
+			"integrity": "sha512-8hsyG+KUYGY0coX6KUCDancA0Vw225KJ2HJO0yCNr1vq5r+lJTleDaJf0K7iOhjw4SWhu03TMBzYTJ9krmzULQ==",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.8",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.1",
+				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"semver": "^6.3.1"
 			},
@@ -1721,11 +1702,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typeof-symbol": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.7.tgz",
-			"integrity": "sha512-VtR8hDy7YLB7+Pet9IarXjg/zgCMSF+1mNS/EQEiEaUPoFXCVsHG64SIxcaaI2zJgRiv+YmgaQESUfWAdbjzgg==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.8.tgz",
+			"integrity": "sha512-adNTUpDCVnmAE58VEqKlAA6ZBlNkMnWD0ZcW76lyNFN3MJniyGFZfNwERVk8Ap56MCnXztmDr19T4mPTztcuaw==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1735,13 +1716,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.7.tgz",
-			"integrity": "sha512-iLD3UNkgx2n/HrjBesVbYX6j0yqn/sJktvbtKKgcaLIQ4bTTQ8obAypc1VpyHPD2y4Phh9zHOaAt8e/L14wCpw==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
+			"integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-create-class-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-create-class-features-plugin": "^7.25.0",
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
 				"@babel/plugin-syntax-typescript": "^7.24.7"
 			},
 			"engines": {
@@ -1796,12 +1778,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.7.tgz",
-			"integrity": "sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.4.tgz",
+			"integrity": "sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.2",
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1811,18 +1793,19 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.7.tgz",
-			"integrity": "sha512-1YZNsc+y6cTvWlDHidMBsQZrZfEFjRIo/BZCT906PMdzOyXtSLTgqGdrpcuTDCXyd11Am5uQULtDIcCfnTc8fQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.4.tgz",
+			"integrity": "sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==",
 			"dependencies": {
-				"@babel/compat-data": "^7.24.7",
-				"@babel/helper-compilation-targets": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
-				"@babel/helper-validator-option": "^7.24.7",
-				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.7",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.7",
+				"@babel/compat-data": "^7.25.4",
+				"@babel/helper-compilation-targets": "^7.25.2",
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-validator-option": "^7.24.8",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.3",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.0",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.0",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.7",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.0",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1843,29 +1826,30 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.24.7",
-				"@babel/plugin-transform-async-generator-functions": "^7.24.7",
+				"@babel/plugin-transform-async-generator-functions": "^7.25.4",
 				"@babel/plugin-transform-async-to-generator": "^7.24.7",
 				"@babel/plugin-transform-block-scoped-functions": "^7.24.7",
-				"@babel/plugin-transform-block-scoping": "^7.24.7",
-				"@babel/plugin-transform-class-properties": "^7.24.7",
+				"@babel/plugin-transform-block-scoping": "^7.25.0",
+				"@babel/plugin-transform-class-properties": "^7.25.4",
 				"@babel/plugin-transform-class-static-block": "^7.24.7",
-				"@babel/plugin-transform-classes": "^7.24.7",
+				"@babel/plugin-transform-classes": "^7.25.4",
 				"@babel/plugin-transform-computed-properties": "^7.24.7",
-				"@babel/plugin-transform-destructuring": "^7.24.7",
+				"@babel/plugin-transform-destructuring": "^7.24.8",
 				"@babel/plugin-transform-dotall-regex": "^7.24.7",
 				"@babel/plugin-transform-duplicate-keys": "^7.24.7",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.0",
 				"@babel/plugin-transform-dynamic-import": "^7.24.7",
 				"@babel/plugin-transform-exponentiation-operator": "^7.24.7",
 				"@babel/plugin-transform-export-namespace-from": "^7.24.7",
 				"@babel/plugin-transform-for-of": "^7.24.7",
-				"@babel/plugin-transform-function-name": "^7.24.7",
+				"@babel/plugin-transform-function-name": "^7.25.1",
 				"@babel/plugin-transform-json-strings": "^7.24.7",
-				"@babel/plugin-transform-literals": "^7.24.7",
+				"@babel/plugin-transform-literals": "^7.25.2",
 				"@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
 				"@babel/plugin-transform-member-expression-literals": "^7.24.7",
 				"@babel/plugin-transform-modules-amd": "^7.24.7",
-				"@babel/plugin-transform-modules-commonjs": "^7.24.7",
-				"@babel/plugin-transform-modules-systemjs": "^7.24.7",
+				"@babel/plugin-transform-modules-commonjs": "^7.24.8",
+				"@babel/plugin-transform-modules-systemjs": "^7.25.0",
 				"@babel/plugin-transform-modules-umd": "^7.24.7",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
 				"@babel/plugin-transform-new-target": "^7.24.7",
@@ -1874,9 +1858,9 @@
 				"@babel/plugin-transform-object-rest-spread": "^7.24.7",
 				"@babel/plugin-transform-object-super": "^7.24.7",
 				"@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-				"@babel/plugin-transform-optional-chaining": "^7.24.7",
+				"@babel/plugin-transform-optional-chaining": "^7.24.8",
 				"@babel/plugin-transform-parameters": "^7.24.7",
-				"@babel/plugin-transform-private-methods": "^7.24.7",
+				"@babel/plugin-transform-private-methods": "^7.25.4",
 				"@babel/plugin-transform-private-property-in-object": "^7.24.7",
 				"@babel/plugin-transform-property-literals": "^7.24.7",
 				"@babel/plugin-transform-regenerator": "^7.24.7",
@@ -1885,16 +1869,16 @@
 				"@babel/plugin-transform-spread": "^7.24.7",
 				"@babel/plugin-transform-sticky-regex": "^7.24.7",
 				"@babel/plugin-transform-template-literals": "^7.24.7",
-				"@babel/plugin-transform-typeof-symbol": "^7.24.7",
+				"@babel/plugin-transform-typeof-symbol": "^7.24.8",
 				"@babel/plugin-transform-unicode-escapes": "^7.24.7",
 				"@babel/plugin-transform-unicode-property-regex": "^7.24.7",
 				"@babel/plugin-transform-unicode-regex": "^7.24.7",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.24.7",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.25.4",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.4",
+				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
-				"core-js-compat": "^3.31.0",
+				"core-js-compat": "^3.37.1",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1968,9 +1952,9 @@
 			"integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-			"integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+			"integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -1979,31 +1963,28 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-			"integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+			"integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
-				"@babel/parser": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/parser": "^7.25.0",
+				"@babel/types": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-			"integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+			"integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.24.7",
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-function-name": "^7.24.7",
-				"@babel/helper-hoist-variables": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
-				"@babel/parser": "^7.24.7",
-				"@babel/types": "^7.24.7",
+				"@babel/generator": "^7.25.6",
+				"@babel/parser": "^7.25.6",
+				"@babel/template": "^7.25.0",
+				"@babel/types": "^7.25.6",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2012,11 +1993,11 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-			"integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+			"integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.24.7",
+				"@babel/helper-string-parser": "^7.24.8",
 				"@babel/helper-validator-identifier": "^7.24.7",
 				"to-fast-properties": "^2.0.0"
 			},
@@ -2314,9 +2295,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-			"integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+			"integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
@@ -2385,20 +2366,20 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.14",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
 			"deprecated": "Use @eslint/config-array instead",
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.2",
+				"@humanwhocodes/object-schema": "^2.0.3",
 				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
@@ -2441,9 +2422,9 @@
 			}
 		},
 		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
 			"engines": {
 				"node": ">=12"
 			},
@@ -3167,9 +3148,9 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
@@ -3383,10 +3364,15 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
 			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
 		},
+		"node_modules/@rtsao/scc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="
+		},
 		"node_modules/@rushstack/eslint-patch": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.3.tgz",
-			"integrity": "sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg=="
+			"version": "1.10.4",
+			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
+			"integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA=="
 		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.24.51",
@@ -3715,18 +3701,18 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.56.10",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-			"integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+			"version": "8.56.12",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+			"integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
 		},
 		"node_modules/@types/express": {
 			"version": "4.17.21",
@@ -3740,9 +3726,20 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "4.19.5",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
-			"integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.0.tgz",
+			"integrity": "sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*",
+				"@types/send": "*"
+			}
+		},
+		"node_modules/@types/express/node_modules/@types/express-serve-static-core": {
+			"version": "4.19.6",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+			"integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
 			"dependencies": {
 				"@types/node": "*",
 				"@types/qs": "*",
@@ -3769,9 +3766,9 @@
 			"integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
 		},
 		"node_modules/@types/http-proxy": {
-			"version": "1.17.14",
-			"resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
-			"integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
+			"version": "1.17.15",
+			"resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
+			"integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -3813,11 +3810,11 @@
 			"integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
 		},
 		"node_modules/@types/node": {
-			"version": "20.14.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-			"integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+			"version": "22.7.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+			"integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.19.2"
 			}
 		},
 		"node_modules/@types/node-forge": {
@@ -3844,9 +3841,9 @@
 			"integrity": "sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw=="
 		},
 		"node_modules/@types/qs": {
-			"version": "6.9.15",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-			"integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
+			"version": "6.9.16",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
+			"integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A=="
 		},
 		"node_modules/@types/range-parser": {
 			"version": "1.2.7",
@@ -3917,9 +3914,9 @@
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.10",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-			"integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+			"version": "8.5.12",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+			"integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -4320,9 +4317,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-			"integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4437,14 +4434,14 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-			"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.4.1"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -4696,17 +4693,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/array.prototype.toreversed": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
-			"integrity": "sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-shim-unscopables": "^1.0.0"
-			}
-		},
 		"node_modules/array.prototype.tosorted": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
@@ -4754,9 +4740,9 @@
 			"integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="
 		},
 		"node_modules/async": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -4772,9 +4758,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.19",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
-			"integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+			"version": "10.4.20",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+			"integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4790,11 +4776,11 @@
 				}
 			],
 			"dependencies": {
-				"browserslist": "^4.23.0",
-				"caniuse-lite": "^1.0.30001599",
+				"browserslist": "^4.23.3",
+				"caniuse-lite": "^1.0.30001646",
 				"fraction.js": "^4.3.7",
 				"normalize-range": "^0.1.2",
-				"picocolors": "^1.0.0",
+				"picocolors": "^1.0.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"bin": {
@@ -4822,19 +4808,19 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
-			"integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+			"integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/axobject-query": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
-			"integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
-			"dependencies": {
-				"deep-equal": "^2.0.5"
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -4923,12 +4909,12 @@
 			}
 		},
 		"node_modules/babel-loader": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
-			"integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.4.1.tgz",
+			"integrity": "sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==",
 			"dependencies": {
 				"find-cache-dir": "^3.3.1",
-				"loader-utils": "^2.0.0",
+				"loader-utils": "^2.0.4",
 				"make-dir": "^3.1.0",
 				"schema-utils": "^2.6.5"
 			},
@@ -5030,12 +5016,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.4.tgz",
-			"integrity": "sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==",
+			"version": "0.10.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+			"integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.1",
-				"core-js-compat": "^3.36.1"
+				"@babel/helper-define-polyfill-provider": "^0.6.2",
+				"core-js-compat": "^3.38.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -5058,22 +5044,25 @@
 			"integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
 		},
 		"node_modules/babel-preset-current-node-syntax": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-			"integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+			"integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
 			"dependencies": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-bigint": "^7.8.3",
-				"@babel/plugin-syntax-class-properties": "^7.8.3",
-				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5",
+				"@babel/plugin-syntax-import-attributes": "^7.24.7",
+				"@babel/plugin-syntax-import-meta": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.3",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-				"@babel/plugin-syntax-top-level-await": "^7.8.3"
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+				"@babel/plugin-syntax-top-level-await": "^7.14.5"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0"
@@ -5261,9 +5250,9 @@
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
 		},
 		"node_modules/browserslist": {
-			"version": "4.23.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-			"integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+			"integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5279,10 +5268,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001629",
-				"electron-to-chromium": "^1.4.796",
-				"node-releases": "^2.0.14",
-				"update-browserslist-db": "^1.0.16"
+				"caniuse-lite": "^1.0.30001663",
+				"electron-to-chromium": "^1.5.28",
+				"node-releases": "^2.0.18",
+				"update-browserslist-db": "^1.1.0"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -5389,9 +5378,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001639",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001639.tgz",
-			"integrity": "sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==",
+			"version": "1.0.30001664",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
+			"integrity": "sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5498,9 +5487,9 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
-			"integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
+			"integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA=="
 		},
 		"node_modules/clean-css": {
 			"version": "5.3.3",
@@ -5715,9 +5704,9 @@
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
 		},
 		"node_modules/core-js": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-			"integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+			"integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -5725,11 +5714,11 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
-			"integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+			"integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
 			"dependencies": {
-				"browserslist": "^4.23.0"
+				"browserslist": "^4.23.3"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5737,9 +5726,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.37.1.tgz",
-			"integrity": "sha512-J/r5JTHSmzTxbiYYrzXg9w1VpqrYt+gexenBE9pugeyhwPZTAEJddyiReJWsLO6uNQ8xJZFbod6XC7KKwatCiA==",
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
+			"integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -6199,11 +6188,11 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -6568,9 +6557,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.815",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.815.tgz",
-			"integrity": "sha512-OvpTT2ItpOXJL7IGcYakRjHCt8L5GrrN/wHCQsRB4PQa1X9fe+X9oen245mIId7s14xvArCGSTIq644yPUKKLg=="
+			"version": "1.5.29",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.29.tgz",
+			"integrity": "sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw=="
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -6820,9 +6809,9 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -6870,15 +6859,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.57.0",
-				"@humanwhocodes/config-array": "^0.11.14",
+				"@eslint/js": "8.57.1",
+				"@humanwhocodes/config-array": "^0.13.0",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"@ungap/structured-clone": "^1.2.0",
@@ -6969,9 +6958,9 @@
 			}
 		},
 		"node_modules/eslint-module-utils": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
-			"integrity": "sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==",
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+			"integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
 			"dependencies": {
 				"debug": "^3.2.7"
 			},
@@ -7010,25 +6999,26 @@
 			}
 		},
 		"node_modules/eslint-plugin-import": {
-			"version": "2.29.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
-			"integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
+			"integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
 			"dependencies": {
-				"array-includes": "^3.1.7",
-				"array.prototype.findlastindex": "^1.2.3",
+				"@rtsao/scc": "^1.1.0",
+				"array-includes": "^3.1.8",
+				"array.prototype.findlastindex": "^1.2.5",
 				"array.prototype.flat": "^1.3.2",
 				"array.prototype.flatmap": "^1.3.2",
 				"debug": "^3.2.7",
 				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.9",
-				"eslint-module-utils": "^2.8.0",
-				"hasown": "^2.0.0",
-				"is-core-module": "^2.13.1",
+				"eslint-module-utils": "^2.9.0",
+				"hasown": "^2.0.2",
+				"is-core-module": "^2.15.1",
 				"is-glob": "^4.0.3",
 				"minimatch": "^3.1.2",
-				"object.fromentries": "^2.0.7",
-				"object.groupby": "^1.0.1",
-				"object.values": "^1.1.7",
+				"object.fromentries": "^2.0.8",
+				"object.groupby": "^1.0.3",
+				"object.values": "^1.2.0",
 				"semver": "^6.3.1",
 				"tsconfig-paths": "^3.15.0"
 			},
@@ -7090,16 +7080,16 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsx-a11y": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.9.0.tgz",
-			"integrity": "sha512-nOFOCaJG2pYqORjK19lqPqxMO/JpvdCZdPtNdxY3kvom3jTvkAbOvQvD8wuD0G8BYR0IGAGYDlzqWJOh/ybn2g==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
+			"integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
 			"dependencies": {
 				"aria-query": "~5.1.3",
 				"array-includes": "^3.1.8",
 				"array.prototype.flatmap": "^1.3.2",
 				"ast-types-flow": "^0.0.8",
-				"axe-core": "^4.9.1",
-				"axobject-query": "~3.1.1",
+				"axe-core": "^4.10.0",
+				"axobject-query": "^4.1.0",
 				"damerau-levenshtein": "^1.0.8",
 				"emoji-regex": "^9.2.2",
 				"es-iterator-helpers": "^1.0.19",
@@ -7115,38 +7105,38 @@
 				"node": ">=4.0"
 			},
 			"peerDependencies": {
-				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
 			}
 		},
 		"node_modules/eslint-plugin-react": {
-			"version": "7.34.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.3.tgz",
-			"integrity": "sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==",
+			"version": "7.37.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.0.tgz",
+			"integrity": "sha512-IHBePmfWH5lKhJnJ7WB1V+v/GolbB0rjS8XYVCSQCZKaQCAUhMoVoOEn1Ef8Z8Wf0a7l8KTJvuZg5/e4qrZ6nA==",
 			"dependencies": {
 				"array-includes": "^3.1.8",
 				"array.prototype.findlast": "^1.2.5",
 				"array.prototype.flatmap": "^1.3.2",
-				"array.prototype.toreversed": "^1.1.2",
 				"array.prototype.tosorted": "^1.1.4",
 				"doctrine": "^2.1.0",
 				"es-iterator-helpers": "^1.0.19",
 				"estraverse": "^5.3.0",
+				"hasown": "^2.0.2",
 				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"minimatch": "^3.1.2",
 				"object.entries": "^1.1.8",
 				"object.fromentries": "^2.0.8",
-				"object.hasown": "^1.1.4",
 				"object.values": "^1.2.0",
 				"prop-types": "^15.8.1",
 				"resolve": "^2.0.0-next.5",
 				"semver": "^6.3.1",
-				"string.prototype.matchall": "^4.0.11"
+				"string.prototype.matchall": "^4.0.11",
+				"string.prototype.repeat": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=4"
 			},
 			"peerDependencies": {
-				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
@@ -7496,9 +7486,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -7698,6 +7688,11 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 		},
+		"node_modules/fast-uri": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
+			"integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row=="
+		},
 		"node_modules/fastq": {
 			"version": "1.17.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -7895,9 +7890,9 @@
 			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.6",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
 			"funding": [
 				{
 					"type": "individual",
@@ -7922,9 +7917,9 @@
 			}
 		},
 		"node_modules/foreground-child": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-			"integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
 				"signal-exit": "^4.0.1"
@@ -8811,9 +8806,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -8828,9 +8823,9 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-			"integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+			"integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
 			"devOptional": true
 		},
 		"node_modules/import-fresh": {
@@ -8857,9 +8852,9 @@
 			}
 		},
 		"node_modules/import-local": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-			"integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+			"integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
 			"dependencies": {
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
@@ -9029,9 +9024,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
-			"integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+			"integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
 			"dependencies": {
 				"hasown": "^2.0.2"
 			},
@@ -9520,14 +9515,11 @@
 			}
 		},
 		"node_modules/jackspeak": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
-			"integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
-			},
-			"engines": {
-				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -9537,9 +9529,9 @@
 			}
 		},
 		"node_modules/jake": {
-			"version": "10.9.1",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.9.1.tgz",
-			"integrity": "sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==",
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+			"integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
 			"dependencies": {
 				"async": "^3.2.3",
 				"chalk": "^4.0.2",
@@ -11115,9 +11107,9 @@
 			}
 		},
 		"node_modules/jest-watch-typeahead/node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+			"version": "17.0.33",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+			"integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
 			"dependencies": {
 				"@types/yargs-parser": "*"
 			}
@@ -11357,9 +11349,9 @@
 			}
 		},
 		"node_modules/jest-watch-typeahead/node_modules/strip-ansi/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
 			"engines": {
 				"node": ">=12"
 			},
@@ -11715,9 +11707,9 @@
 			}
 		},
 		"node_modules/launch-editor": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.0.tgz",
-			"integrity": "sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.9.1.tgz",
+			"integrity": "sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==",
 			"dependencies": {
 				"picocolors": "^1.0.0",
 				"shell-quote": "^1.8.1"
@@ -11987,9 +11979,9 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
-			"integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.1.tgz",
+			"integrity": "sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==",
 			"dependencies": {
 				"schema-utils": "^4.0.0",
 				"tapable": "^2.2.1"
@@ -12049,9 +12041,9 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/multicast-dns": {
 			"version": "7.2.5",
@@ -12138,9 +12130,9 @@
 			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -12192,9 +12184,9 @@
 			}
 		},
 		"node_modules/nwsapi": {
-			"version": "2.2.10",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
-			"integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ=="
+			"version": "2.2.13",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.13.tgz",
+			"integrity": "sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ=="
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -12324,22 +12316,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/object.hasown": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
-			"integrity": "sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==",
-			"dependencies": {
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/object.values": {
@@ -12482,9 +12458,9 @@
 			}
 		},
 		"node_modules/package-json-from-dist": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -12590,12 +12566,9 @@
 			}
 		},
 		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
-			"integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
-			"engines": {
-				"node": "14 || >=16.14"
-			}
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
 		},
 		"node_modules/path-to-regexp": {
 			"version": "0.1.10",
@@ -12616,9 +12589,9 @@
 			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -12720,9 +12693,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-			"integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
+			"version": "8.4.47",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+			"integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -12739,8 +12712,8 @@
 			],
 			"dependencies": {
 				"nanoid": "^3.3.7",
-				"picocolors": "^1.0.1",
-				"source-map-js": "^1.2.0"
+				"picocolors": "^1.1.0",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
@@ -13221,9 +13194,9 @@
 			}
 		},
 		"node_modules/postcss-load-config/node_modules/yaml": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
-			"integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+			"integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -13422,18 +13395,24 @@
 			}
 		},
 		"node_modules/postcss-nested": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
-			"integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+			"integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.11"
+				"postcss-selector-parser": "^6.1.1"
 			},
 			"engines": {
 				"node": ">=12.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.14"
@@ -13820,9 +13799,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
-			"integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -14581,9 +14560,9 @@
 			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
 		},
 		"node_modules/regenerate-unicode-properties": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.1.tgz",
-			"integrity": "sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+			"integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
 			"dependencies": {
 				"regenerate": "^1.4.2"
 			},
@@ -14839,9 +14818,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.79.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-			"integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+			"version": "2.79.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+			"integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
@@ -14992,9 +14971,9 @@
 			"integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
 		},
 		"node_modules/sass": {
-			"version": "1.79.3",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.79.3.tgz",
-			"integrity": "sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==",
+			"version": "1.79.4",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.79.4.tgz",
+			"integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
 			"devOptional": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
@@ -15116,14 +15095,14 @@
 			}
 		},
 		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-			"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.4.1"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -15164,9 +15143,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -15217,11 +15196,6 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
-		},
-		"node_modules/send/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.2",
@@ -15441,9 +15415,9 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -15762,6 +15736,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/string.prototype.repeat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+			"integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+			"dependencies": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			}
+		},
 		"node_modules/string.prototype.trim": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
@@ -15947,9 +15930,9 @@
 			}
 		},
 		"node_modules/sucrase/node_modules/glob": {
-			"version": "10.4.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
-			"integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
 				"jackspeak": "^3.1.2",
@@ -15960,9 +15943,6 @@
 			},
 			"bin": {
 				"glob": "dist/esm/bin.mjs"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -16126,9 +16106,9 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.4",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
-			"integrity": "sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==",
+			"version": "3.4.13",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.13.tgz",
+			"integrity": "sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==",
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",
@@ -16221,9 +16201,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.31.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.31.1.tgz",
-			"integrity": "sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==",
+			"version": "5.34.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.34.1.tgz",
+			"integrity": "sha512-FsJZ7iZLd/BXkz+4xrRTGJ26o/6VTjQytUk8b8OxkwcD2I+79VPJlz7qss1+zE7h8GNIScFqXcDyJ/KqBYZFVA==",
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.8.2",
@@ -16445,9 +16425,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -16588,16 +16568,16 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
 			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -16620,14 +16600,14 @@
 			"integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
-			"integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+			"integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
 			"engines": {
 				"node": ">=4"
 			}
@@ -16645,9 +16625,9 @@
 			}
 		},
 		"node_modules/unicode-match-property-value-ecmascript": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
-			"integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+			"integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
 			"engines": {
 				"node": ">=4"
 			}
@@ -16702,9 +16682,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.16",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-			"integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -16720,8 +16700,8 @@
 				}
 			],
 			"dependencies": {
-				"escalade": "^3.1.2",
-				"picocolors": "^1.0.1"
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.0"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -16842,9 +16822,9 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
-			"integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -16875,9 +16855,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.94.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
-			"integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
+			"version": "5.95.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+			"integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
 			"dependencies": {
 				"@types/estree": "^1.0.5",
 				"@webassemblyjs/ast": "^1.12.1",
@@ -17000,9 +16980,9 @@
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/ws": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -17192,12 +17172,12 @@
 			}
 		},
 		"node_modules/which-builtin-type": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
-			"integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
+			"integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
 			"dependencies": {
-				"function.prototype.name": "^1.1.5",
-				"has-tostringtag": "^1.0.0",
+				"function.prototype.name": "^1.1.6",
+				"has-tostringtag": "^1.0.2",
 				"is-async-function": "^2.0.0",
 				"is-date-object": "^1.0.5",
 				"is-finalizationregistry": "^1.0.2",
@@ -17206,8 +17186,8 @@
 				"is-weakref": "^1.0.2",
 				"isarray": "^2.0.5",
 				"which-boxed-primitive": "^1.0.2",
-				"which-collection": "^1.0.1",
-				"which-typed-array": "^1.1.9"
+				"which-collection": "^1.0.2",
+				"which-typed-array": "^1.1.15"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -17340,14 +17320,14 @@
 			}
 		},
 		"node_modules/workbox-build/node_modules/ajv": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-			"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.4.1"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",

--- a/package.json
+++ b/package.json
@@ -3,18 +3,18 @@
 	"version": "0.1.0",
 	"private": true,
 	"dependencies": {
-		"async": "^3.2.5",
+		"async": "^3.2.6",
 		"nth-check": "^2.1.1",
-		"react": "^18.2.0",
+		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"react-helmet-async": "^2.0.4",
+		"react-helmet-async": "^2.0.5",
 		"react-icons": "^5.3.0",
 		"react-router-dom": "^6.26.2",
 		"react-scripts": "^5.0.1",
 		"web-vitals": "^4.2.3"
 	},
 	"devDependencies": {
-		"sass": "^1.79.3"
+		"sass": "^1.79.4"
 	},
 	"scripts": {
 		"start": "react-scripts start",


### PR DESCRIPTION
The changes in this commit update the versions of the `@babel/types` and `terser` dependencies in the `package-lock.json` file. The updates include:

- Updating `@babel/types` from version 7.24.7 to 7.25.6
- Updating various `@babel` plugin dependencies to newer versions
- Updating `terser` from version 5.31.1 to 5.34.1

These updates are likely to improve the functionality, performance, and security of the application.