### PR TITLE
chore(gitignore): update ignores for Next.js and IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-<<<<<<< HEAD
-node_modules
-.DS_Store
-.idea
-.cache
-.parcel-cache
-dist
-=======
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
@@ -30,4 +22,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .idea/
->>>>>>> 692867ab1950dd928e30861796239d726c35a98f
+.next/
+.idea
+.cache


### PR DESCRIPTION
The changes to the .gitignore file improve the project's ignore
configuration by adding ignores for the .next/ directory used by
Next.js, as well as additional IDE-specific files like .idea.
This helps keep the repository clean and focused on the project's
source code.